### PR TITLE
Stage grub packages needed for build instead of fetching as build-deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ GRUB_MODULES = \
 	video
 
 all:
-	dd if=/usr/lib/grub/i386-pc/boot.img of=pc-boot.img bs=440 count=1
+	dd if=$(SNAPCRAFT_STAGE)/usr/lib/grub/i386-pc/boot.img of=pc-boot.img bs=440 count=1
 	/bin/echo -n -e '\x90\x90' | dd of=pc-boot.img seek=102 bs=1 conv=notrunc
 	grub-mkimage -O i386-pc -o pc-core.img -p '(,gpt2)/EFI/ubuntu' $(GRUB_MODULES)
 	# The first sector of the core image requires an absolute pointer to the
@@ -63,8 +63,8 @@ all:
 	# BIOS boot partition must be defined with an absolute offset.  The
 	# particular value here is 2049, or 0x01 0x08 0x00 0x00 in little-endian.
 	/bin/echo -n -e '\x01\x08\x00\x00' | dd of=pc-core.img seek=500 bs=1 conv=notrunc
-	cp /usr/lib/shim/shimx64.efi.signed shim.efi.signed
-	cp /usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed grubx64.efi
+	cp $(SNAPCRAFT_STAGE)/usr/lib/shim/shimx64.efi.signed shim.efi.signed
+	cp $(SNAPCRAFT_STAGE)/usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed grubx64.efi
 
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ GRUB_MODULES = \
 all:
 	dd if=$(SNAPCRAFT_STAGE)/usr/lib/grub/i386-pc/boot.img of=pc-boot.img bs=440 count=1
 	/bin/echo -n -e '\x90\x90' | dd of=pc-boot.img seek=102 bs=1 conv=notrunc
-	grub-mkimage -O i386-pc -o pc-core.img -p '(,gpt2)/EFI/ubuntu' $(GRUB_MODULES)
+	grub-mkimage -d $(SNAPCRAFT_STAGE)/usr/lib/grub/i386-pc/ -O i386-pc -o pc-core.img -p '(,gpt2)/EFI/ubuntu' $(GRUB_MODULES)
 	# The first sector of the core image requires an absolute pointer to the
 	# second sector of the image.  Since this is always hard-coded, it means our
 	# BIOS boot partition must be defined with an absolute offset.  The

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,11 +9,17 @@ confinement: strict
 icon: icon.png
 
 parts:
-  grub:
-    source: .
-    plugin: make
-    build-packages:
+  grub-prepare:
+    plugin: nil
+    stage-packages:
       - grub-efi-amd64-signed
       - grub-pc-bin
       - shim-signed
-        
+    prime: [ -* ]
+  grub:
+    source: .
+    build-packages:
+      - grub-common
+    plugin: make
+    after: [grub-prepare]
+


### PR DESCRIPTION
Declaring the grub-related packages as build-dependencies in snapcraft.yaml can cause conflicts with packages installed on the host, like in the case where the host machine has grub-pc installed on a xenial system. This causes conflicts in satisfying build dependencies.