### PR TITLE
Add mmx64.efi (MokManager) to support mokutil

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,9 @@ all:
 	/bin/echo -n -e '\x01\x08\x00\x00' | dd of=pc-core.img seek=500 bs=1 conv=notrunc
 	cp $(SNAPCRAFT_STAGE)/usr/lib/shim/shimx64.efi.signed shim.efi.signed
 	cp $(SNAPCRAFT_STAGE)/usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed grubx64.efi
+	cp $(SNAPCRAFT_STAGE)/usr/lib/shim/mmx64.efi mmx64.efi
 
 
 install:
-	install -m 644 pc-boot.img pc-core.img shim.efi.signed grubx64.efi $(DESTDIR)/
+	install -m 644 pc-boot.img pc-core.img shim.efi.signed grubx64.efi mmx64.efi $(DESTDIR)/
 	install -m 644 grub.conf grub.cfg $(DESTDIR)/

--- a/gadget.yaml
+++ b/gadget.yaml
@@ -26,3 +26,5 @@ volumes:
             target: EFI/boot/bootx64.efi
           - source: grub.cfg
             target: EFI/ubuntu/grub.cfg
+          - source: mmx64.efi
+            target: EFI/boot/mmx64.efi


### PR DESCRIPTION
To support MokUtil properly, mmx64.efi (MokManger) should be included in the gadget snap.

Though there is no mokutil included in core and core18 and there is no mokutil snap, users still can upload the mokutil binary and run it by themselves. Another way is to include mokutil in core and core18.