### PR TITLE
Add mmx64.efi (MokManager) to support mokutil

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,9 @@ all:
 	/bin/echo -n -e '\x01\x08\x00\x00' | dd of=pc-core.img seek=500 bs=1 conv=notrunc
 	cp $(SNAPCRAFT_STAGE)/usr/lib/shim/shimx64.efi.signed shim.efi.signed
 	cp $(SNAPCRAFT_STAGE)/usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed grubx64.efi
+	cp $(SNAPCRAFT_STAGE)/usr/lib/shim/mmx64.efi mmx64.efi
 
 
 install:
-	install -m 644 pc-boot.img pc-core.img shim.efi.signed grubx64.efi $(DESTDIR)/
+	install -m 644 pc-boot.img pc-core.img shim.efi.signed grubx64.efi mmx64.efi $(DESTDIR)/
 	install -m 644 grub.conf grub.cfg $(DESTDIR)/

--- a/gadget.yaml
+++ b/gadget.yaml
@@ -24,5 +24,7 @@ volumes:
             target: EFI/boot/grubx64.efi
           - source: shim.efi.signed
             target: EFI/boot/bootx64.efi
+          - source: mmx64.efi
+            target: EFI/boot/mmx64.efi
           - source: grub.cfg
             target: EFI/ubuntu/grub.cfg


### PR DESCRIPTION
Same thing for Ubuntu Core 18.

To support MokUtil, we need to include the mmx64.efi (MokManger).

Though there is no mokutil included in core and core18 and there is no mokutil snap, users still can upload the mokutil binary and run it by themselves.
Another approach is that we can include mokutil in core and core18 to simplify the operation.