### PR TITLE
add .travis.yml to enable basic smoke testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+os: linux
+dist: xenial
+sudo: enabled
+script:
+  - sudo apt-get update
+  - sudo apt-get install --yes --no-install-recommends snapd
+  - sudo snap wait system seed.loaded
+  - sudo snap install --classic snapcraft
+  - sudo snapcraft

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,11 @@ language: python
 os: linux
 dist: xenial
 sudo: enabled
+addons:
+  snaps:
+    - name: snapcraft
+      channel: stable
+      classic: true
+
 script:
-  - sudo apt-get update
-  - sudo apt-get install --yes --no-install-recommends snapd
-  - sudo snap wait system seed.loaded
-  - sudo snap install --classic snapcraft
   - sudo snapcraft


### PR DESCRIPTION
This adds a .travis.yml that will build the snap to ensure
that this part works. With that in place we can add additional
tests later.