### PR TITLE
Fix kernel path in recovery grub.cfg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,4 +69,4 @@ all:
 
 install:
 	install -m 644 pc-boot.img pc-core.img shim.efi.signed grubx64.efi $(DESTDIR)/
-	install -m 644 grub.cfg-recovery grub.cfg-normal grub.conf $(DESTDIR)/
+	install -m 644 grub.cfg-recovery grub.cfg-normal grub-recovery.conf grub.conf $(DESTDIR)/

--- a/grub-recovery.conf
+++ b/grub-recovery.conf
@@ -1,0 +1,1 @@
+grub.cfg-recovery

--- a/grub.cfg-recovery
+++ b/grub.cfg-recovery
@@ -45,7 +45,7 @@ for label in /systems/*; do
 
     # We could "source /systems/$snapd_recovery/grub.cfg" here as well
     menuentry "Recover using $label" --hotkey=r --id=recover-$label $snapd_recovery_kernel recover $label {
-        loopback loop /snaps/$2
+        loopback loop $2
         linux (loop)/kernel.img snapd_recovery_mode=$3 snapd_recovery=$4 $standard_params
         if [ -e (loop)/ubuntu-core-initramfs.img ]; then
             initrd (loop)/ubuntu-core-initramfs.img
@@ -54,7 +54,7 @@ for label in /systems/*; do
         fi
     }
     menuentry "Install using $label" --hotkey=i --id=install-$label $snapd_recovery_kernel recover $label {
-        loopback loop /snaps/$2
+        loopback loop $2
         linux (loop)/kernel.img snapd_recovery_mode=$3 snapd_recovery=$4 $standard_params
         if [ -e (loop)/ubuntu-core-initramfs.img ]; then
             initrd (loop)/ubuntu-core-initramfs.img


### PR DESCRIPTION
The bootenv variable will now contain the full kernel path to allow
us to load the kernel from different locations, so remove the hardcoded
path from the configuration file.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>