### PR TITLE
grub.cfg-recovery: add run mode chainloading

### DIFF
--- a/grub.cfg-recovery
+++ b/grub.cfg-recovery
@@ -21,6 +21,16 @@ fi
 # standard cmdline params
 set standard_params="console=ttyS0 console=tty1 panic=-1"
 
+if [ "$snapd_recovery_mode" = "run" ]; then
+    default="Run"
+    # XXX: we want to just run in this mode eventually
+    #      instead of displaying a menu here
+    menuentry "Run" {
+        # XXX: use label instead of hardcoding gpt3
+        chainloader (hd0,gpt3)/EFI/boot/grubx64.efi
+    }
+fi
+
 # globbing in grub does not sort
 for label in /systems/*; do
     regexp --set 1:label "/([0-9]*)\$" "$label"


### PR DESCRIPTION
When `snapd_recovery_mode` is set to `run` we need to boot directly
into the installed system. For now just add a menu entry and make
that default. Eventually we will have code in run mode to detect
key-presses to switch back to recovery.