### PR TITLE
grub.cfg-normal: set snapd_recovery_mode= run in run mode

### DIFF
--- a/grub.cfg-normal
+++ b/grub.cfg-normal
@@ -32,7 +32,7 @@ elif [ "$snap_mode" = "trying" ]; then
 fi
 
 set label="ubuntu-data"
-set cmdline="root=LABEL=$label snap_core=$snap_core snap_kernel=$snap_kernel ro net.ifnames=0 init=/lib/systemd/systemd console=ttyS0 console=tty1 panic=-1"
+set cmdline="root=LABEL=$label snap_core=$snap_core snap_kernel=$snap_kernel ro net.ifnames=0 init=/lib/systemd/systemd console=ttyS0 console=tty1 panic=-1 snapd_recovery_mode=run"
 
 menuentry "$snap_menuentry" {
     search --label ubuntu-boot --set=ubuntu_boot


### PR DESCRIPTION
The grub.cfg-normal will run from the ubuntu-boot partition. In
order for "the-tool" to run and call snap-bootstrap to setup the
right mount in run-mode this kernel commandline has to be set.

The-tool has a "ConditionKernelCommandLine=snapd_recovery_mode"
so it only runs with that.

There is a bunch more cleanup that should be done in this file but to
keep churn minimal it just does this one change.