### PR TITLE
grub.cfg-normal: go back to the UC16 way of loading the kernel

### DIFF
--- a/grub.cfg-normal
+++ b/grub.cfg-normal
@@ -35,7 +35,8 @@ set label="ubuntu-data"
 set cmdline="root=LABEL=$label snap_core=$snap_core snap_kernel=$snap_kernel ro net.ifnames=0 init=/lib/systemd/systemd console=ttyS0 console=tty1 panic=-1 snapd_recovery_mode=run"
 
 menuentry "$snap_menuentry" {
-    search --label ubuntu-boot --set=ubuntu_boot
-    linux ($ubuntu_boot)/kernel.img $cmdline systemd.debug-shell=1
-    initrd ($ubuntu_boot)/initrd.img
+    search --label $label --set=writable
+    loopback loop ($writable)/system-data/var/lib/snapd/snaps/$snap_kernel
+    linux (loop)/kernel.img $cmdline
+    initrd (loop)/initrd.img
 }


### PR DESCRIPTION
In run mode this will go back to the old way of loading the kernel
but from the "ubuntu-data" partition. This is just a step on the
way so that we can create integration tests for image creation
and seeding. Soon this will be replaced with the UC20 single-file
(no grubenv) way of booting in "run" mode.