### PR TITLE
gadget.yaml: increase default size of ubuntu-data to 3G

### DIFF
--- a/gadget.yaml
+++ b/gadget.yaml
@@ -46,4 +46,4 @@ volumes:
         filesystem: ext4
         type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
         # XXX: make auto-grow to partition
-        size: 1G
+        size: 3G


### PR DESCRIPTION
Until we have auto-grow of the partition or auto-size from the
snap-bootstrap create-partitions code we need a bigger default
so that we can actually run spread tests on this.