### PR TITLE
grub.cfg-boot: use $prefix/kernel instead of $ubuntu-boot/kernel

### DIFF
--- a/grub.cfg-boot
+++ b/grub.cfg-boot
@@ -30,12 +30,15 @@ fi
 
 search --label ubuntu-boot --set=ubuntu_boot
 
-if [ -e ($ubuntu_boot)/$kernel ]; then
+if [ -e $prefix/$kernel ]; then
 menuentry "Run Ubuntu Core 20" {
-    chainloader ($ubuntu_boot)/$kernel $cmdline
+    # use $prefix because the symlink manipulation at runtime for kernel snap 
+    # upgrades, etc. should only need the /boot/grub/ directory, not the 
+    # /EFI/ubuntu/ directory
+    chainloader $prefix/$kernel $cmdline
 }
 else
-menuentry "Run Ubuntu Core 20" {
+menuentry "Run Ubuntu Core 20 compatibility mode" {
     search --label ubuntu-data --set=writable
     loopback loop ($writable)/system-data/var/lib/snapd/snaps/$snap_kernel
     chainloader (loop)/kernel.efi $cmdline


### PR DESCRIPTION
Using $prefix/kernel allows us at runtime to not look at the root directory of the ubuntu-boot partition and just use grub as-is mounted at /boot/grub.

Also change the name of the menuentry when we do boot an old kernel through the temporary compatibility mode. This will be removed entirely when snapd is updated to extract kernel assets properly.

The PR's to snapd that will allow us to eliminate the compatibility mode are: https://github.com/snapcore/snapd/pull/7992 and https://github.com/snapcore/snapd/pull/8001. However, we can't merge https://github.com/snapcore/snapd/pull/8001 until this has been merged, otherwise it will fail to boot.