### PR TITLE
Makefile: add "regex" to the modules for the non-uefi grub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ GRUB_MODULES = \
 	part_gpt \
 	png \
 	reboot \
+	regex \
 	search \
 	search_fs_uuid \
 	search_fs_file \


### PR DESCRIPTION
This should allow booting of UC20 systems (without encryption) on
non-UEFI systems.