### PR TITLE
grub.cfg-recovery: fix typo, filter vars when loading them

### DIFF
--- a/grub.cfg-recovery
+++ b/grub.cfg-recovery
@@ -1,7 +1,7 @@
 set default=0
 set timeout=3
 
-load_env --file /EFI/ubuntu/grubenv
+load_env --file /EFI/ubuntu/grubenv snapd_recovery_mode snapd_recovery_system
 
 # if no default boot mode set, pick one
 if [ -z "$snapd_recovery_mode" ]; then

--- a/grub.cfg-recovery
+++ b/grub.cfg-recovery
@@ -37,13 +37,13 @@ for label in /systems/*; do
         set best="$label"
     fi
     # if grubenv did not pick mode-system, use best one
-    if [ -z "$snapd_recovery" ]; then
+    if [ -z "$snapd_recovery_system" ]; then
         default=$snapd_recovery_mode-$best
     fi
     set snapd_recovery_kernel=
     load_env --file /systems/$label/grubenv snapd_recovery_kernel
 
-    # We could "source /systems/$snapd_recovery/grub.cfg" here as well
+    # We could "source /systems/$snapd_recovery_system/grub.cfg" here as well
     menuentry "Recover using $label" --hotkey=r --id=recover-$label $snapd_recovery_kernel recover $label {
         loopback loop $2
         chainloader (loop)/kernel.efi snapd_recovery_mode=$3 snapd_recovery_system=$4 $standard_params


### PR DESCRIPTION
This had a typo of `snapd_recovery` instead of `snapd_recovery_system`.

Also, as per the spec, we should only be loading specific vars from the grubenv's, which AIUI is more of a protection against programming errors than it is a physical attack vector.