### PR TITLE
gadget.yaml: reduce data partition size to 1G

### DIFF
--- a/gadget.yaml
+++ b/gadget.yaml
@@ -45,5 +45,4 @@ volumes:
         role: system-data
         filesystem: ext4
         type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
-        # XXX: make auto-grow to partition
-        size: 3G
+        size: 1G


### PR DESCRIPTION
The data partition is now extended during install to use all the
space available in the block device, so we can set the default
size back to a lower value to generate smaller image files.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>