### PR TITLE
grub-recovery.conf: don't make run mode default just because ubuntu-boot exists

### DIFF
--- a/grub-recovery.conf
+++ b/grub-recovery.conf
@@ -23,7 +23,6 @@ fi
 search --no-floppy --set=boot_fs --label ubuntu-boot
 
 if [ -n "$boot_fs" ]; then
-    default="run"
     menuentry "Continue to run mode" --hotkey=n --id=run {
         chainloader ($boot_fs)/EFI/boot/grubx64.efi
     }


### PR DESCRIPTION


For the case of re-installing or recovering, we will still have the ubuntu-boot partition around, but we explicitly don't want to make run mode the default here because we will have snapd_recovery_system set and snapd_recovery_mode set too, and so grub should use that.