### PR TITLE
gadget.yaml: bump edition

### DIFF
--- a/gadget.yaml
+++ b/gadget.yaml
@@ -5,6 +5,8 @@ volumes:
       - name: mbr
         type: mbr
         size: 440
+        update:
+          edition: 1
         content:
           - image: pc-boot.img
       - name: BIOS Boot
@@ -12,6 +14,8 @@ volumes:
         size: 1M
         offset: 1M
         offset-write: mbr+92
+        update:
+          edition: 1
         content:
           - image: pc-core.img
       - name: ubuntu-seed
@@ -20,6 +24,8 @@ volumes:
         # UEFI will boot the ESP partition by default first
         type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         size: 1200M
+        update:
+          edition: 1
         content:
           - source: grubx64.efi
             target: EFI/boot/grubx64.efi
@@ -33,6 +39,8 @@ volumes:
         type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
         # whats the appropriate size?
         size: 750M
+        update:
+          edition: 1
         content:
           - source: grubx64.efi
             target: EFI/boot/grubx64.efi


### PR DESCRIPTION
grub.confs & grub images have been changed in the 20/* tracks, without
bumping editions. Meaning, those who have installed from old images,
may not have received gadget updates and still use old kernel cmdline,
old shim, old grub, with different / wrong signatures.

Imho edition should be bumped on every upload of gadget, when its
contents changes. And it should also perform resealing if needed.

Signed-off-by: Dimitri John Ledkov <xnox@ubuntu.com>