### PR TITLE
gadget: bump edition to 2, using production signing keys for everything.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,11 +66,6 @@ all:
 	/bin/echo -n -e '\x01\x08\x00\x00' | dd of=pc-core.img seek=500 bs=1 conv=notrunc
 	cp $(SNAPCRAFT_STAGE)/usr/lib/shim/shimx64.efi.signed shim.efi.signed
 	cp $(SNAPCRAFT_STAGE)/usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed grubx64.efi
-	sbattach --remove shim.efi.signed
-	#sbattach --remove grubx64.efi
-	sbsign --key snakeoil/PkKek-1-snakeoil.key --cert snakeoil/PkKek-1-snakeoil.pem --output shim.efi.signed shim.efi.signed
-	#sbsign --key snakeoil/PkKek-1-snakeoil.key --cert snakeoil/PkKek-1-snakeoil.pem --output grubx64.efi grubx64.efi
-
 
 install:
 	install -m 644 pc-boot.img pc-core.img shim.efi.signed grubx64.efi $(DESTDIR)/

--- a/gadget.yaml
+++ b/gadget.yaml
@@ -15,7 +15,7 @@ volumes:
         offset: 1M
         offset-write: mbr+92
         update:
-          edition: 1
+          edition: 2
         content:
           - image: pc-core.img
       - name: ubuntu-seed
@@ -25,7 +25,7 @@ volumes:
         type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         size: 1200M
         update:
-          edition: 1
+          edition: 2
         content:
           - source: grubx64.efi
             target: EFI/boot/grubx64.efi


### PR DESCRIPTION
shim signed with MS keys & grub signed with the UC20 keys.

Signed-off-by: Dimitri John Ledkov <xnox@ubuntu.com>