### PR TITLE
22 focal with fallback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,11 +69,17 @@ all:
 	# And yet people try to rebuild this gadget snap
 	pull-lp-debs -a amd64 -D ppa --ppa ppa:canonical-foundations/uc20-staging-ppa shim-signed focal
 	dpkg-deb -x shim-signed_*.deb shim/
+	pull-lp-debs -a amd64 -D ppa --ppa ppa:canonical-foundations/uc20-staging-ppa shim focal
+	dpkg-deb -x shim_*.deb shim/
 	pull-lp-debs -a amd64 -D ppa --ppa ppa:canonical-foundations/uc20-staging-ppa grub-efi-amd64-signed focal || wget https://launchpad.net/~canonical-signing/+archive/ubuntu/uc20/+build/19903679/+files/grub-efi-amd64-signed_1.142.5+uc20.1+2.04-1ubuntu26.3_amd64.deb
 	dpkg-deb -x grub-efi-amd64-signed_*.deb grub/
 	cp shim/usr/lib/shim/shimx64.efi.dualsigned shim.efi.signed
+	cp shim/usr/lib/shim/fbx64.efi .
+	cp shim/usr/lib/shim/mmx64.efi .
+	cp shim/usr/lib/shim/BOOTX64.CSV .
 	cp grub/usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed grubx64.efi
 
 install:
 	install -m 644 pc-boot.img pc-core.img shim.efi.signed grubx64.efi $(DESTDIR)/
+	install -m 644 fbx64.efi mmx64.efi BOOTX64.CSV $(DESTDIR)/
 	install -m 644 grub.conf $(DESTDIR)/

--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,15 @@ all:
 	# BIOS boot partition must be defined with an absolute offset.  The
 	# particular value here is 2049, or 0x01 0x08 0x00 0x00 in little-endian.
 	/bin/echo -n -e '\x01\x08\x00\x00' | dd of=pc-core.img seek=500 bs=1 conv=notrunc
-	cp $(SNAPCRAFT_STAGE)/usr/lib/shim/shimx64.efi.dualsigned shim.efi.signed
-	cp $(SNAPCRAFT_STAGE)/usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed grubx64.efi
+	# We must pull in dualsigned shim & grub with UC20 signature
+	# Do it by hand, as snapcraft doesn't have support for PPA archives yet
+	# And yet people try to rebuild this gadget snap
+	pull-lp-debs -a amd64 -D ppa --ppa ppa:canonical-foundations/uc20-staging-ppa shim-signed focal
+	dpkg-deb -x shim-signed_*.deb shim/
+	pull-lp-debs -a amd64 -D ppa --ppa ppa:canonical-foundations/uc20-staging-ppa grub-efi-amd64-signed focal || wget https://launchpad.net/~canonical-signing/+archive/ubuntu/uc20/+build/19903679/+files/grub-efi-amd64-signed_1.142.5+uc20.1+2.04-1ubuntu26.3_amd64.deb
+	dpkg-deb -x grub-efi-amd64-signed_*.deb grub/
+	cp shim/usr/lib/shim/shimx64.efi.dualsigned shim.efi.signed
+	cp grub/usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed grubx64.efi
 
 install:
 	install -m 644 pc-boot.img pc-core.img shim.efi.signed grubx64.efi $(DESTDIR)/

--- a/gadget.yaml
+++ b/gadget.yaml
@@ -29,9 +29,17 @@ volumes:
           edition: 2
         content:
           - source: grubx64.efi
-            target: EFI/boot/grubx64.efi
+            target: EFI/ubuntu/grubx64.efi
           - source: shim.efi.signed
-            target: EFI/boot/bootx64.efi
+            target: EFI/BOOT/BOOTX64.efi
+          - source: fbx64.efi
+            target: EFI/BOOT/fbx64.efi
+          - source: mmx64.efi
+            target: EFI/BOOT/mmx64.efi
+          - source: BOOTX64.CSV
+            target: EFI/ubuntu/BOOTX64.CSV
+          - source: shim.efi.signed
+            target: EFI/ubuntu/shimx64.efi
       - name: ubuntu-boot
         role: system-boot
         filesystem: ext4

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -13,6 +13,9 @@ parts:
   grub-prepare:
     plugin: nil
     build-snaps: [snapd/latest/edge]
+    build-packages:
+      - ubuntu-dev-tools
+      - wget
     stage-packages:
       - grub-efi-amd64-signed
       - grub-pc-bin

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: pc
-version: '20-0.4'
+version: '20-1'
 type: gadget
 base: core20
 summary: PC gadget for generic devices


### PR DESCRIPTION
This branch adds reproducible building;
using *focal* binaries;
adds support for fallback.

TODO: test that encrypted boot works