### PR TITLE
snap: increase size of ubuntu-save to 32Mb

### DIFF
--- a/gadget.yaml
+++ b/gadget.yaml
@@ -49,7 +49,7 @@ volumes:
         role: system-save
         filesystem: ext4
         type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
-        size: 16M
+        size: 64M
       - name: ubuntu-data
         role: system-data
         filesystem: ext4

--- a/gadget.yaml
+++ b/gadget.yaml
@@ -49,7 +49,7 @@ volumes:
         role: system-save
         filesystem: ext4
         type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
-        size: 64M
+        size: 32M
       - name: ubuntu-data
         role: system-data
         filesystem: ext4


### PR DESCRIPTION
Currently the ubuntu-save partition needs to be bigger than 32Mb 
for devices that have 4k sector sizes. This is because of a bug in
how snapd calls mkfs [1] and because of a chance in cryptsetup [2].

With the bugfix for [1] the usable space of the ubuntu-save is very
small (just 3.8Mb) and much less than the 6.9Mb that UC20 has for
512b sector sizes (there is no support for 4kb sectors in the uc20 
cryptsetup). So to ensure there is enough usable space on ubuntu-save
this commit increases the size of ubuntu-save to 32Mb which translates
to around 18Mb of usable space.


With 33 we have:
```
mvo@ubuntu:~$ df -h /run/mnt/ubuntu-save/
Filesystem                                                    Size  Used Avail Use% Mounted on
/dev/mapper/ubuntu-save-4f616498-7704-487b-939c-90986debe7f7   21M  120K   19M   1% /run/mnt/ubuntu-save
```

For reference on UC20 we have (with 16mb):
```
mvo@ubuntu:~$ df -h /run/mnt/ubuntu-save/
Filesystem                                                    Size  Used Avail Use% Mounted on
/dev/mapper/ubuntu-save-498a65bb-30ce-492c-a8aa-301adb79228e  7.8M  187K  6.9M   3% /run/mnt/ubuntu-save
```

[1]  https://bugs.launchpad.net/snappy/+bug/1968356
[2] https://gitlab.com/cryptsetup/cryptsetup/-/merge_requests/135

