### PR TITLE
snapcraft.yaml: allow building outside of launchpad with old binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,16 +56,25 @@ GRUB_MODULES = \
 	video
 
 all:
-	dd if=$(SNAPCRAFT_STAGE)/usr/lib/grub/i386-pc/boot.img of=pc-boot.img bs=440 count=1
+	dd if=/usr/lib/grub/i386-pc/boot.img of=pc-boot.img bs=440 count=1
 	/bin/echo -n -e '\x90\x90' | dd of=pc-boot.img seek=102 bs=1 conv=notrunc
-	grub-mkimage -d $(SNAPCRAFT_STAGE)/usr/lib/grub/i386-pc/ -O i386-pc -o pc-core.img -p '(,gpt2)/EFI/ubuntu' $(GRUB_MODULES)
+	grub-mkimage -O i386-pc -o pc-core.img -p '(,gpt2)/EFI/ubuntu' $(GRUB_MODULES)
 	# The first sector of the core image requires an absolute pointer to the
 	# second sector of the image.  Since this is always hard-coded, it means our
 	# BIOS boot partition must be defined with an absolute offset.  The
 	# particular value here is 2049, or 0x01 0x08 0x00 0x00 in little-endian.
 	/bin/echo -n -e '\x01\x08\x00\x00' | dd of=pc-core.img seek=500 bs=1 conv=notrunc
-	cp $(SNAPCRAFT_STAGE)/usr/lib/shim/shimx64.efi.dualsigned shim.efi.signed
-	cp $(SNAPCRAFT_STAGE)/usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed grubx64.efi
+	# We must pull in dualsigned shim & grub with UC20 signature
+	# Do it by hand, as snapcraft doesn't have support for PPA archives yet
+	# And yet people try to rebuild this gadget snap
+	pull-lp-debs -a amd64 -D ppa --ppa ppa:canonical-foundations/uc20-staging-ppa shim-signed focal
+	dpkg-deb -x shim-signed_*.deb shim/
+	pull-lp-debs -a amd64 -D ppa --ppa ppa:canonical-foundations/uc20-staging-ppa shim focal
+	dpkg-deb -x shim_*.deb shim/
+	pull-lp-debs -a amd64 -D ppa --ppa ppa:canonical-foundations/uc20-staging-ppa grub2-signed focal
+	dpkg-deb -x grub-efi-amd64-signed_*.deb grub/
+	cp shim/usr/lib/shim/shimx64.efi.dualsigned shim.efi.signed
+	cp grub/usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed grubx64.efi
 
 install:
 	install -m 644 pc-boot.img pc-core.img shim.efi.signed grubx64.efi $(DESTDIR)/

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -10,19 +10,10 @@ grade: stable
 icon: icon.png
 
 parts:
-  grub-prepare:
-    plugin: nil
-    build-snaps: [snapd/latest/edge]
-    stage-packages:
-      - grub-efi-amd64-signed
-      - grub-pc-bin
-      - shim-signed
-      - sbsigntool
-    prime: [ -* ]
   grub:
     source: .
     build-packages:
+      - ubuntu-dev-tools
+      - grub-pc-bin
       - grub-common
     plugin: make
-    after: [grub-prepare]
-


### PR DESCRIPTION
The measurements in 2.06 grub are currently incorrect, force using
focal binaries, without requirement to specify archive in launchpad
/+snap/ page such that one can build the gadget locally correctly too.

Also remove all unused dependencies. And it is no longer required to
stage build-deps, instead of build-depend on them, as they are no
longer conflicting with anything installed on the host.

Fixes #57

Backport from 00ea33892ff0b258d2e4136d7b911a9c8ce0605d