### PR TITLE
Support kernel with EFI runtime turned off

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,5 +77,6 @@ all:
 install:
 	install -m 644 pc-boot.img pc-core.img shim.efi.signed grubx64.efi $(DESTDIR)/
 	install -m 644 grub.conf $(DESTDIR)/
+	install -m 644 cmdline.extra $(DESTDIR)/
 	install -d $(DESTDIR)/meta
 	install -m 644 gadget.yaml $(DESTDIR)/meta/

--- a/cmdline.extra
+++ b/cmdline.extra
@@ -1,0 +1,1 @@
+efi=runtime


### PR DESCRIPTION
Kernel configuration supports turning off EFI runtime services on boot. Meaning, the kernel is booted with UEFI Secureboot and yet it doesn't allow access to efivarfs or any EFI services.

One such common kernel configuration is for Ubuntu Realtime Kernel. That is driven by the fact that EFI runtime services are unpredictable in their timings (reading and writing efivars can trigger a blocking EFI garbage collection of unknown amount of time).

On the other hand, Ubuntu Core sealed full disk encryption is a key feature.

Specify `efi=runtime` kernel command line option, such that stock EFI gadget can be used with realtime-kernel and have full disk encryption out of the box.

Note that snap refresh of gadget & kernel snaps, may result in realtime latency spikes.