### PR TITLE
Build from snapcraft.yaml and use ucdev PPA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,4 @@
 all: mbr.img
-	# We must pull in dualsigned shim & grub with UC20 signature
-	# Do it by hand, as snapcraft doesn't have support for PPA archives yet
-	# And yet people try to rebuild this gadget snap
-	pull-lp-debs -a amd64 -D ppa --ppa ppa:canonical-foundations/uc20-staging-ppa shim-signed jammy
-	dpkg-deb -x shim-signed_*.deb shim/
-	pull-lp-debs -a amd64 -D ppa --ppa ppa:canonical-foundations/uc20-staging-ppa grub2-signed jammy
-	dpkg-deb -x grub-efi-amd64-signed_*.deb grub/
-	cp shim/usr/lib/shim/shimx64.efi.dualsigned shim.efi.signed
-	cp grub/usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed grubx64.efi
 
 legacy-bios/mbr.o: legacy-bios/mbr.s
 	gcc -Wall -O0 -c -m16 $< -o $@
@@ -19,9 +10,6 @@ mbr.img: legacy-bios/mbr.bin
 	dd if=legacy-bios/mbr.bin of=mbr.img bs=440 count=1
 
 install:
-	install -m 644 mbr.img shim.efi.signed grubx64.efi $(DESTDIR)/
-	install -m 644 grub.conf $(DESTDIR)/
-	install -d $(DESTDIR)/meta
-	install -m 644 gadget.yaml $(DESTDIR)/meta/
+	install -m 644 mbr.img $(DESTDIR)/
 
 .PHONY: install all

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -38,12 +38,12 @@ parts:
     override-build: |
       set -x
       # Make sure we have signatures from the UC certificates
-      sbverify --list "$SNAPCRAFT_PART_INSTALL"/usr/lib/shim/shimx64.efi.dualsigned |
+      sbverify --list "$CRAFT_PART_INSTALL"/usr/lib/shim/shimx64.efi.dualsigned |
           grep -E 'Canonical Ltd. Secure Boot Signing \(Ubuntu Core'
-      sbverify --list "$SNAPCRAFT_PART_INSTALL"/usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed |
+      sbverify --list "$CRAFT_PART_INSTALL"/usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed |
           grep -E 'Canonical Ltd. Secure Boot Signing \(Ubuntu Core'
 
-      mbr_img="$SNAPCRAFT_PART_INSTALL"/pc-boot.img
+      mbr_img="$CRAFT_PART_INSTALL"/pc-boot.img
       dd if=/usr/lib/grub/i386-pc/boot.img of="$mbr_img" bs=440 count=1
       printf '\x90\x90' | dd of="$mbr_img" seek=102 bs=1 conv=notrunc
       GRUB_MODULES="\
@@ -84,7 +84,7 @@ parts:
         test \
         true \
         video"
-      bios_img="$SNAPCRAFT_PART_INSTALL"/pc-core.img
+      bios_img="$CRAFT_PART_INSTALL"/pc-core.img
       # shellcheck disable=SC2086
       grub-mkimage -O i386-pc -o "$bios_img" -p '(,gpt2)/EFI/ubuntu' $GRUB_MODULES
       # The first sector of the core image requires an absolute pointer to the
@@ -92,7 +92,7 @@ parts:
       # BIOS boot partition must be defined with an absolute offset.  The
       # particular value here is 2049, or 0x01 0x08 0x00 0x00 in little-endian.
       printf '\x01\x08\x00\x00' | dd of="$bios_img" seek=500 bs=1 conv=notrunc
-      install -m 644 /dev/null "$SNAPCRAFT_PART_INSTALL"/grub.conf
+      install -m 644 /dev/null "$CRAFT_PART_INSTALL"/grub.conf
     organize:
       usr/lib/shim/shimx64.efi.dualsigned: shim.efi.signed
       usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed: grubx64.efi

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -23,6 +23,11 @@ hooks:
       # DO NOT check this API key into a publicly accessible VCS
       MODEL_APIKEY: ""
 
+
+# Min version to support shim 15.7
+assumes:
+  - snapd2.59.3
+
 parts:
   # Temporary workaround until pinning is supported by snapcraft
   pin-ucdev:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,12 +9,9 @@ confinement: strict
 grade: stable
 icon: icon.png
 
-parts:
-  grub:
-    source: .
-    build-packages:
-      - ubuntu-dev-tools
-    plugin: make
+package-repositories:
+ - type: apt
+   ppa: ucdev/uc-staging-ppa
 
 hooks:
   prepare-device:
@@ -25,3 +22,76 @@ hooks:
       # for instructions on how to generate an API key
       # DO NOT check this API key into a publicly accessible VCS
       MODEL_APIKEY: ""
+
+parts:
+  grub:
+    plugin: nil
+    source: .
+    build-packages:
+      - ubuntu-dev-tools
+      - grub-pc-bin
+      - grub-common
+    stage-packages:
+      - grub-efi-amd64-signed
+      - shim-signed
+    override-build: |
+      set -x
+      mbr_img="$SNAPCRAFT_PART_INSTALL"/pc-boot.img
+      dd if=/usr/lib/grub/i386-pc/boot.img of="$mbr_img" bs=440 count=1
+      printf '\x90\x90' | dd of="$mbr_img" seek=102 bs=1 conv=notrunc
+      GRUB_MODULES="\
+        all_video \
+        biosdisk \
+        boot \
+        cat \
+        chain \
+        configfile \
+        echo \
+        ext2 \
+        fat \
+        font \
+        gettext \
+        gfxmenu \
+        gfxterm \
+        gfxterm_background \
+        gzio \
+        halt \
+        jpeg \
+        keystatus \
+        loadenv \
+        loopback \
+        linux \
+        memdisk \
+        minicmd \
+        normal \
+        part_gpt \
+        png \
+        reboot \
+        regexp \
+        search \
+        search_fs_uuid \
+        search_fs_file \
+        search_label \
+        sleep \
+        squash4 \
+        test \
+        true \
+        video"
+      bios_img="$SNAPCRAFT_PART_INSTALL"/pc-core.img
+      # shellcheck disable=SC2086
+      grub-mkimage -O i386-pc -o "$bios_img" -p '(,gpt2)/EFI/ubuntu' $GRUB_MODULES
+      # The first sector of the core image requires an absolute pointer to the
+      # second sector of the image.  Since this is always hard-coded, it means our
+      # BIOS boot partition must be defined with an absolute offset.  The
+      # particular value here is 2049, or 0x01 0x08 0x00 0x00 in little-endian.
+      printf '\x01\x08\x00\x00' | dd of="$bios_img" seek=500 bs=1 conv=notrunc
+      install -m 644 /dev/null "$SNAPCRAFT_PART_INSTALL"/grub.conf
+    organize:
+      usr/lib/shim/shimx64.efi.dualsigned: shim.efi.signed
+      usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed: grubx64.efi
+    prime:
+      - shim.efi.signed
+      - grubx64.efi
+      - grub.conf
+      - pc-boot.img
+      - pc-core.img

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -24,7 +24,21 @@ hooks:
       MODEL_APIKEY: ""
 
 parts:
+  # Temporary workaround until pinning is supported by snapcraft
+  pin-ucdev:
+    plugin: nil
+    override-pull: |
+      # This is run before the pull step of grub part, so we make sure
+      # we get the packages from the PPA.
+      set -x
+      cat <<'EOF' > /etc/apt/preferences.d/ucdev
+      Package: *
+      Pin: release LP-PPA-ucdev-uc-staging-ppa,a=jammy,n=jammy
+      Pin: origin ppa.launchpad.net
+      Pin-Priority: 1000
+      EOF
   grub:
+    after: [ pin-ucdev ]
     plugin: nil
     source: .
     build-packages:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -31,11 +31,18 @@ parts:
       - ubuntu-dev-tools
       - grub-pc-bin
       - grub-common
+      - sbsigntool
     stage-packages:
       - grub-efi-amd64-signed
       - shim-signed
     override-build: |
       set -x
+      # Make sure we have signatures from the UC certificates
+      sbverify --list "$SNAPCRAFT_PART_INSTALL"/usr/lib/shim/shimx64.efi.dualsigned |
+          grep -E 'Canonical Ltd. Secure Boot Signing \(Ubuntu Core'
+      sbverify --list "$SNAPCRAFT_PART_INSTALL"/usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed |
+          grep -E 'Canonical Ltd. Secure Boot Signing \(Ubuntu Core'
+
       mbr_img="$SNAPCRAFT_PART_INSTALL"/pc-boot.img
       dd if=/usr/lib/grub/i386-pc/boot.img of="$mbr_img" bs=440 count=1
       printf '\x90\x90' | dd of="$mbr_img" seek=102 bs=1 conv=notrunc

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -37,6 +37,11 @@ parts:
       Pin: origin ppa.launchpad.net
       Pin-Priority: 1000
       EOF
+  mbr:
+    source: .
+    build-packages:
+      - ubuntu-dev-tools
+    plugin: make
   grub:
     after: [ pin-ucdev ]
     plugin: nil
@@ -56,56 +61,7 @@ parts:
           grep -E 'Canonical Ltd. Secure Boot Signing \(Ubuntu Core'
       sbverify --list "$CRAFT_PART_INSTALL"/usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed |
           grep -E 'Canonical Ltd. Secure Boot Signing \(Ubuntu Core'
-
-      mbr_img="$CRAFT_PART_INSTALL"/pc-boot.img
-      dd if=/usr/lib/grub/i386-pc/boot.img of="$mbr_img" bs=440 count=1
-      printf '\x90\x90' | dd of="$mbr_img" seek=102 bs=1 conv=notrunc
-      GRUB_MODULES="\
-        all_video \
-        biosdisk \
-        boot \
-        cat \
-        chain \
-        configfile \
-        echo \
-        ext2 \
-        fat \
-        font \
-        gettext \
-        gfxmenu \
-        gfxterm \
-        gfxterm_background \
-        gzio \
-        halt \
-        jpeg \
-        keystatus \
-        loadenv \
-        loopback \
-        linux \
-        memdisk \
-        minicmd \
-        normal \
-        part_gpt \
-        png \
-        reboot \
-        regexp \
-        search \
-        search_fs_uuid \
-        search_fs_file \
-        search_label \
-        sleep \
-        squash4 \
-        test \
-        true \
-        video"
-      bios_img="$CRAFT_PART_INSTALL"/pc-core.img
-      # shellcheck disable=SC2086
-      grub-mkimage -O i386-pc -o "$bios_img" -p '(,gpt2)/EFI/ubuntu' $GRUB_MODULES
-      # The first sector of the core image requires an absolute pointer to the
-      # second sector of the image.  Since this is always hard-coded, it means our
-      # BIOS boot partition must be defined with an absolute offset.  The
-      # particular value here is 2049, or 0x01 0x08 0x00 0x00 in little-endian.
-      printf '\x01\x08\x00\x00' | dd of="$bios_img" seek=500 bs=1 conv=notrunc
+      # grub.conf lets snapd identify grub as the bootloader on boot
       install -m 644 /dev/null "$CRAFT_PART_INSTALL"/grub.conf
     organize:
       usr/lib/shim/shimx64.efi.dualsigned: shim.efi.signed
@@ -114,5 +70,3 @@ parts:
       - shim.efi.signed
       - grubx64.efi
       - grub.conf
-      - pc-boot.img
-      - pc-core.img


### PR DESCRIPTION

Remove makefile and do special steps from an override-build section
instead.

Take now signed grub and shim form the ucdev/uc-staging-ppa PPA, using
package-repositories. Now we use epochs in the version of
grub-efi-amd64-signed and shim-signed packages, so the build should
always take the ones from the PPA instead of those in the archive, as
`2:<version>` will always be greater than the package version in the
latter. Nonetheless, do an additional static check for this.

Forward-ported from https://github.com/snapcore/pc-amd64-gadget/pull/65