### PR TITLE
Update boot partition edition

### DIFF
--- a/gadget.yaml
+++ b/gadget.yaml
@@ -39,7 +39,7 @@ volumes:
         # whats the appropriate size?
         size: 750M
         update:
-          edition: 1
+          edition: 2
         content:
           - source: grubx64.efi
             target: EFI/boot/grubx64.efi


### PR DESCRIPTION
Now we have newer grub and shim. Nonetheless we bump only the edition
number for the ubuntu-boot partition for the moment, to minimize risks.