### PR TITLE
Increase boot partition size for classic gadget

### DIFF
--- a/gadget.yaml
+++ b/gadget.yaml
@@ -18,7 +18,7 @@ volumes:
         type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         filesystem: vfat
         filesystem-label: system-boot
-        size: 50M
+        size: 200M
         content:
           - source: grubx64.efi
             target: EFI/boot/grubx64.efi

--- a/gadget.yaml
+++ b/gadget.yaml
@@ -18,7 +18,7 @@ volumes:
         type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         filesystem: vfat
         filesystem-label: system-boot
-        size: 200M
+        size: 512M
         content:
           - source: grubx64.efi
             target: EFI/boot/grubx64.efi


### PR DESCRIPTION
The following math was done to come up with the number of 512:

```
In [1]: fudge_factor = 2

In [2]: num_copies = 1 # we should only need one copy of the kernel for pc-amd64 images

In [3]: kernel_size = 11

In [4]: initrd_size = 169

In [5]: other_boot_assets = 22 # /boot/grub and /boot/EFI

In [6]: boot_size = fudge_factor * (num_copies * ( kernel_size + initrd_size +other_boot_assets))

In [7]: boot_size
Out[7]: 404
```

Then rounding up from 404 to a nice power of 2 we get 512.