### PR TITLE
Copy shim in EFI/ubuntu/shimx64.efi

### DIFF
--- a/gadget.yaml
+++ b/gadget.yaml
@@ -32,6 +32,8 @@ volumes:
             target: EFI/boot/grubx64.efi
           - source: shim.efi.signed
             target: EFI/boot/bootx64.efi
+          - source: shim.efi.signed
+            target: EFI/ubuntu/shimx64.efi
       - name: ubuntu-boot
         role: system-boot
         filesystem: ext4


### PR DESCRIPTION
fwupd expects a copy of shim to be available there.