### PR TITLE
update gadget.yaml to reflect location and size of existing partitions

### DIFF
--- a/gadget.yaml
+++ b/gadget.yaml
@@ -2,29 +2,13 @@ volumes:
   pc:
     # bootloader configuration is shipped and managed by snapd
     bootloader: grub
+    schema: gpt
     structure:
-      - name: mbr
-        type: mbr
-        size: 440
-        update:
-          edition: 1
-        content:
-          - image: pc-boot.img
-      - name: BIOS Boot
-        type: DA,21686148-6449-6E6F-744E-656564454649
-        size: 1M
-        offset: 1M
-        offset-write: mbr+92
-        update:
-          edition: 2
-        content:
-          - image: pc-core.img
       - name: EFI System partition
         filesystem: vfat
-        # UEFI will boot the ESP partition by default first
-        type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
-        # TODO make this realistically smaller?
-        size: 99M
+        type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+        offset: 17408
+        size: 249982976
         update:
           edition: 2
         content:
@@ -32,14 +16,17 @@ volumes:
             target: EFI/boot/grubx64.efi
           - source: shim.efi.signed
             target: EFI/boot/bootx64.efi
+      - # Recovery partition
+        type: E3C9E316-0B5C-4DB8-817D-F92DF00215AE
+        size: 8192000000
       - name: ubuntu-boot
         role: system-boot
         filesystem: ext4
-        type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
+        type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
         # Such that potentially there is space to later slot-in 1200M
         # large ubuntu-seed partition
         # TODO check that offset is correct given the ESP size (?!)
-        offset: 1202M
+        offset: 9202M
         size: 750M
         update:
           edition: 1
@@ -52,10 +39,10 @@ volumes:
         # XXX this makes snap pack unhappy ATM!
         # role: system-save
         filesystem: ext4
-        type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
+        type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
         size: 32M
       - name: ubuntu-data
         role: system-data
         filesystem: ext4
-        type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
+        type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
         size: 4G


### PR DESCRIPTION
Running sfdisk on the target system gives output like this:

![image002](https://user-images.githubusercontent.com/672022/202291561-400a99ea-6e10-48e0-8907-812340924ca7.png)

This is my attempt to make gadget.yaml match this (slightly surprising) output.