### PR TITLE
Revert role to system-seed

### DIFF
--- a/gadget.yaml
+++ b/gadget.yaml
@@ -5,7 +5,7 @@ volumes:
     schema: gpt
     structure:
       - name: EFI System partition
-        role: system-seed-null
+        role: system-seed
         filesystem: vfat
         type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         size: 250000384


### PR DESCRIPTION
This is needed so we mount this partition in /run/mnt/ubuntu-seed. In the future the behaviour of system-seed-null should be the same, so this is a workaround. Mounting is needed as we check binaries in ubuntu-seed to find out if sealing the disk key is necessary.