### PR TITLE
add an explicit offset to the recovery partition

### DIFF
--- a/gadget.yaml
+++ b/gadget.yaml
@@ -8,7 +8,8 @@ volumes:
         role: system-seed-null
         filesystem: vfat
         type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
-        size: 250000384
+        size: 248951808
+        offset: 1048576
         update:
           edition: 2
         content:
@@ -19,6 +20,7 @@ volumes:
       - # Recovery partition
         type: E3C9E316-0B5C-4DB8-817D-F92DF00215AE
         size: 8192000000
+        offset: 250000384
       - name: ubuntu-boot
         role: system-boot
         filesystem: ext4


### PR DESCRIPTION
I haven't tested this (not really sure how to in a sensible amount of time), but I don't think the current version will put the recovery partition in the right place