### PR TITLE
gadget.yaml: allow optional "dhc-dev-mode" kernel commandline

### DIFF
--- a/gadget.yaml
+++ b/gadget.yaml
@@ -47,3 +47,6 @@ volumes:
         filesystem: ext4
         type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
         size: 4G
+kernel-cmdline:
+    allow:
+      - dhc-dev-mode


### PR DESCRIPTION
This will allow to use the new kernel cmdline options, see: https://github.com/snapcore/snapd/pull/12605/files#diff-febc07409227a4ecf0bc8520f8e7b36fcc2e71677951c6abb1ff78017b53445bR23