### PR TITLE
Pull shim and grub from the Ubuntu archive

### DIFF
--- a/gadget.yaml
+++ b/gadget.yaml
@@ -35,8 +35,6 @@ volumes:
         content:
           - source: grubx64.efi
             target: EFI/boot/grubx64.efi
-          - source: shim.efi.signed
-            target: EFI/boot/bootx64.efi
       - name: ubuntu-save
         role: system-save
         filesystem: ext4

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: xinyi-pc-classic
-version: '22-0.4'
+version: '22.04-0.1'
 type: gadget
 base: core22
 summary: Xinyi PC Classic gadget

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -8,6 +8,10 @@ description: |
 confinement: strict
 grade: stable
 
+# Min version to support fully FDE on classic
+assumes:
+  - snapd2.59.3
+
 parts:
   boot:
     plugin: nil

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@ confinement: strict
 grade: stable
 
 parts:
-  grub:
+  boot:
     plugin: nil
     stage-packages:
       - grub-efi-amd64-signed

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -25,6 +25,8 @@ parts:
       - shim.efi.signed
       - grubx64.efi
       - grub.conf
+      - usr/share/doc/shim-signed
+      - usr/share/doc/grub-efi-amd64-signed
   cmdline:
     plugin: dump
     source: dump

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: xinyi-pc-classic
-adopt-info: pc
+version: '22-0.4'
 type: gadget
 base: core22
 summary: Xinyi PC Classic gadget
@@ -9,14 +9,22 @@ confinement: strict
 grade: stable
 
 parts:
-  pc:
+  grub:
     plugin: nil
-    override-pull: |
-      craftctl set version="$(snap info pc | sed -n 's|^  22/edge: *\(22-[0-9.]*\) *202.-.*|\1|p')"
-    stage-snaps:
-      - pc/22/edge
-    stage:
-      - -pc-boot.img
+    stage-packages:
+      - grub-efi-amd64-signed
+      - shim-signed
+    override-build: |
+      set -x
+      # grub.conf lets snapd identify grub as the bootloader on boot
+      install -m 644 /dev/null "$CRAFT_PART_INSTALL"/grub.conf
+    organize:
+      usr/lib/shim/shimx64.efi.dualsigned: shim.efi.signed
+      usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed: grubx64.efi
+    prime:
+      - shim.efi.signed
+      - grubx64.efi
+      - grub.conf
   cmdline:
     plugin: dump
     source: dump


### PR DESCRIPTION
We do not want the UC certificate in the xinyi gadget, so we pull shim/grub from archive instead of staging from the pc gadget. This also cleans up files that were pulled and not really needed.