### PR TITLE
Copy grub to EFI/ubuntu/ folder in seed partition

### DIFF
--- a/gadget.yaml
+++ b/gadget.yaml
@@ -31,6 +31,8 @@ volumes:
         content:
           - source: grubx64.efi
             target: EFI/boot/grubx64.efi
+          - source: grubx64.efi
+            target: EFI/ubuntu/grubx64.efi
           - source: shim.efi.signed
             target: EFI/boot/bootx64.efi
           - source: shim.efi.signed


### PR DESCRIPTION
Now that we have EFI/ubuntu/shimx64.efi, some BIOS seem to try to boot with it as first option, and then the boot fails as grub is not found. Copy it to EFI/ubuntu/ to fix that.