### PR TITLE
Revert "Copy shim in EFI/ubuntu/shimx64.efi"

### DIFF
--- a/gadget.yaml
+++ b/gadget.yaml
@@ -33,8 +33,6 @@ volumes:
             target: EFI/boot/grubx64.efi
           - source: shim.efi.signed
             target: EFI/boot/bootx64.efi
-          - source: shim.efi.signed
-            target: EFI/ubuntu/shimx64.efi
       - name: ubuntu-boot
         role: system-boot
         filesystem: ext4


### PR DESCRIPTION
It has been found out that some fw vendors (Lenovo and Dell) run EFI/ubuntu/shimx64.efi with higher priority than EFI/BOOT/BOOTX64.EFI, which makes the system unable to boot as there is not EFI/ubuntu/grubx64.efi to jump to from the shim.

The solution is for the moment to revert copying around the shim to EFI/ubuntu, as we cannot simply copy grub to the same place as that could break measurements easily (the device path is part of the EFI_IMAGE_LOAD_EVENT measured in PCR 4) so devices with TPM backed FDE would not boot.

To fix this in a clean way so we can put back EFI/ubuntu/shimx64.efi we will need to start writing EFI boot entries on Ubuntu Core installation.

This reverts commit adadcea8d2107953eb3f422fd341767d67e2acf0.