### PR TITLE
gadget: move efi files in ubuntu-seed to EFI/ubuntu and rename boot*efi to shim*.efi

### DIFF
--- a/gadget/gadget-amd64.yaml
+++ b/gadget/gadget-amd64.yaml
@@ -27,12 +27,12 @@ volumes:
         type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         size: 1200M
         update:
-          edition: 2
+          edition: 3
         content:
           - source: grubx64.efi
-            target: EFI/boot/grubx64.efi
+            target: EFI/ubuntu/grubx64.efi
           - source: shim.efi.signed
-            target: EFI/boot/bootx64.efi
+            target: EFI/ubuntu/shimx64.efi
       - name: ubuntu-boot
         role: system-boot
         filesystem: ext4

--- a/gadget/gadget-arm64.yaml
+++ b/gadget/gadget-arm64.yaml
@@ -11,12 +11,12 @@ volumes:
         type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         size: 1200M
         update:
-          edition: 2
+          edition: 3
         content:
           - source: grubaa64.efi
-            target: EFI/boot/grubaa64.efi
+            target: EFI/ubuntu/grubaa64.efi
           - source: shim.efi.signed
-            target: EFI/boot/bootaa64.efi
+            target: EFI/ubuntu/shimaa64.efi
       - name: ubuntu-boot
         role: system-boot
         filesystem: ext4


### PR DESCRIPTION
This is part of ongoing work to explicitly set EFI boot variables on install of Ubuntu Core, thus ceasing to rely solely on default boot EFI behavior, which can be complicated by circumstances such as attached external media.

See the following for associated work to support this change on the snapd side by setting EFI boot variables (WIP): https://github.com/snapcore/snapd/pull/13025/files

Also, there was previous work to support more complete EFI artifacts from both pc-gadget and snapd:
- https://github.com/snapcore/snapd/pull/11437
- https://github.com/snapcore/pc-gadget/pull/55
- https://github.com/snapcore/pc-gadget/pull/56

And for those internal to Canonical, here is the specification for this project: https://docs.google.com/document/d/1s-XJ56Ur6mQdJ3gVtWdJs12odgknM_2nqQ72RzWUDho

Once this is merged into core24, the plan is to backport similar changes to core 22, core20, etc.