### PR TITLE
22 Support shim fallback bootchain

### DIFF
--- a/gadget/gadget-amd64.yaml
+++ b/gadget/gadget-amd64.yaml
@@ -28,9 +28,17 @@ volumes:
           edition: 2
         content:
           - source: grubx64.efi
-            target: EFI/boot/grubx64.efi
+            target: EFI/ubuntu/grubx64.efi
           - source: shim.efi.signed
-            target: EFI/boot/bootx64.efi
+            target: EFI/BOOT/BOOTX64.efi
+          - source: fbx64.efi
+            target: EFI/BOOT/fbx64.efi
+          - source: mmx64.efi
+            target: EFI/BOOT/mmx64.efi
+          - source: BOOTX64.CSV
+            target: EFI/ubuntu/BOOTX64.CSV
+          - source: shim.efi.signed
+            target: EFI/ubuntu/shimx64.efi
       - name: ubuntu-boot
         role: system-boot
         filesystem: ext4

--- a/gadget/gadget-amd64.yaml
+++ b/gadget/gadget-amd64.yaml
@@ -25,7 +25,7 @@ volumes:
         type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         size: 1200M
         update:
-          edition: 3
+          edition: 2
         content:
           - source: shim.efi.signed
             target: EFI/BOOT/BOOTX64.efi

--- a/gadget/gadget-amd64.yaml
+++ b/gadget/gadget-amd64.yaml
@@ -31,8 +31,6 @@ volumes:
             target: EFI/BOOT/BOOTX64.efi
           - source: fbx64.efi
             target: EFI/BOOT/fbx64.efi
-          - source: grubx64.efi
-            target: EFI/BOOT/grubx64.efi
           - source: mmx64.efi
             target: EFI/BOOT/mmx64.efi
           - source: BOOTX64.CSV

--- a/gadget/gadget-amd64.yaml
+++ b/gadget/gadget-amd64.yaml
@@ -31,8 +31,6 @@ volumes:
             target: EFI/BOOT/BOOTX64.efi
           - source: fbx64.efi
             target: EFI/BOOT/fbx64.efi
-          - source: mmx64.efi
-            target: EFI/BOOT/mmx64.efi
           - source: BOOTX64.CSV
             target: EFI/ubuntu/BOOTX64.CSV
           - source: grubx64.efi

--- a/gadget/gadget-amd64.yaml
+++ b/gadget/gadget-amd64.yaml
@@ -28,6 +28,8 @@ volumes:
           edition: 2
         content:
           - source: grubx64.efi
+            target: EFI/BOOT/grubx64.efi
+          - source: grubx64.efi
             target: EFI/ubuntu/grubx64.efi
           - source: shim.efi.signed
             target: EFI/BOOT/BOOTX64.efi

--- a/gadget/gadget-amd64.yaml
+++ b/gadget/gadget-amd64.yaml
@@ -39,6 +39,8 @@ volumes:
             target: EFI/ubuntu/BOOTX64.CSV
           - source: grubx64.efi
             target: EFI/ubuntu/grubx64.efi
+          - source: mmx64.efi
+            target: EFI/ubuntu/mmx64.efi
           - source: shim.efi.signed
             target: EFI/ubuntu/shimx64.efi
       - name: ubuntu-boot

--- a/gadget/gadget-amd64.yaml
+++ b/gadget/gadget-amd64.yaml
@@ -25,7 +25,7 @@ volumes:
         type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         size: 1200M
         update:
-          edition: 2
+          edition: 3
         content:
           - source: grubx64.efi
             target: EFI/BOOT/grubx64.efi

--- a/gadget/gadget-amd64.yaml
+++ b/gadget/gadget-amd64.yaml
@@ -27,18 +27,18 @@ volumes:
         update:
           edition: 3
         content:
-          - source: grubx64.efi
-            target: EFI/BOOT/grubx64.efi
-          - source: grubx64.efi
-            target: EFI/ubuntu/grubx64.efi
           - source: shim.efi.signed
             target: EFI/BOOT/BOOTX64.efi
           - source: fbx64.efi
             target: EFI/BOOT/fbx64.efi
+          - source: grubx64.efi
+            target: EFI/BOOT/grubx64.efi
           - source: mmx64.efi
             target: EFI/BOOT/mmx64.efi
           - source: BOOTX64.CSV
             target: EFI/ubuntu/BOOTX64.CSV
+          - source: grubx64.efi
+            target: EFI/ubuntu/grubx64.efi
           - source: shim.efi.signed
             target: EFI/ubuntu/shimx64.efi
       - name: ubuntu-boot

--- a/gadget/gadget-arm64.yaml
+++ b/gadget/gadget-arm64.yaml
@@ -13,18 +13,18 @@ volumes:
         update:
           edition: 3
         content:
-          - source: grubaa64.efi
-            target: EFI/BOOT/grubaa64.efi
-          - source: grubaa64.efi
-            target: EFI/ubuntu/grubaa64.efi
           - source: shim.efi.signed
             target: EFI/BOOT/BOOTAA64.efi
           - source: fbaa64.efi
             target: EFI/BOOT/fbaa64.efi
+          - source: grubaa64.efi
+            target: EFI/BOOT/grubaa64.efi
           - source: mmaa64.efi
             target: EFI/BOOT/mmaa64.efi
           - source: BOOTAA64.CSV
             target: EFI/ubuntu/BOOTAA64.CSV
+          - source: grubaa64.efi
+            target: EFI/ubuntu/grubaa64.efi
           - source: shim.efi.signed
             target: EFI/ubuntu/shimaa64.efi
       - name: ubuntu-boot

--- a/gadget/gadget-arm64.yaml
+++ b/gadget/gadget-arm64.yaml
@@ -17,8 +17,6 @@ volumes:
             target: EFI/BOOT/BOOTAA64.efi
           - source: fbaa64.efi
             target: EFI/BOOT/fbaa64.efi
-          - source: mmaa64.efi
-            target: EFI/BOOT/mmaa64.efi
           - source: BOOTAA64.CSV
             target: EFI/ubuntu/BOOTAA64.CSV
           - source: grubaa64.efi

--- a/gadget/gadget-arm64.yaml
+++ b/gadget/gadget-arm64.yaml
@@ -17,8 +17,6 @@ volumes:
             target: EFI/BOOT/BOOTAA64.efi
           - source: fbaa64.efi
             target: EFI/BOOT/fbaa64.efi
-          - source: grubaa64.efi
-            target: EFI/BOOT/grubaa64.efi
           - source: mmaa64.efi
             target: EFI/BOOT/mmaa64.efi
           - source: BOOTAA64.CSV

--- a/gadget/gadget-arm64.yaml
+++ b/gadget/gadget-arm64.yaml
@@ -11,7 +11,7 @@ volumes:
         type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         size: 1200M
         update:
-          edition: 2
+          edition: 3
         content:
           - source: grubaa64.efi
             target: EFI/BOOT/grubaa64.efi

--- a/gadget/gadget-arm64.yaml
+++ b/gadget/gadget-arm64.yaml
@@ -14,9 +14,17 @@ volumes:
           edition: 2
         content:
           - source: grubaa64.efi
-            target: EFI/boot/grubaa64.efi
+            target: EFI/ubuntu/grubaa64.efi
           - source: shim.efi.signed
-            target: EFI/boot/bootaa64.efi
+            target: EFI/BOOT/BOOTAA64.efi
+          - source: fbaa64.efi
+            target: EFI/BOOT/fbaa64.efi
+          - source: mmaa64.efi
+            target: EFI/BOOT/mmaa64.efi
+          - source: BOOTAA64.CSV
+            target: EFI/ubuntu/BOOTAA64.CSV
+          - source: shim.efi.signed
+            target: EFI/ubuntu/shimaa64.efi
       - name: ubuntu-boot
         role: system-boot
         filesystem: ext4

--- a/gadget/gadget-arm64.yaml
+++ b/gadget/gadget-arm64.yaml
@@ -11,7 +11,7 @@ volumes:
         type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         size: 1200M
         update:
-          edition: 3
+          edition: 2
         content:
           - source: shim.efi.signed
             target: EFI/BOOT/BOOTAA64.efi

--- a/gadget/gadget-arm64.yaml
+++ b/gadget/gadget-arm64.yaml
@@ -14,6 +14,8 @@ volumes:
           edition: 2
         content:
           - source: grubaa64.efi
+            target: EFI/BOOT/grubaa64.efi
+          - source: grubaa64.efi
             target: EFI/ubuntu/grubaa64.efi
           - source: shim.efi.signed
             target: EFI/BOOT/BOOTAA64.efi

--- a/gadget/gadget-arm64.yaml
+++ b/gadget/gadget-arm64.yaml
@@ -25,6 +25,8 @@ volumes:
             target: EFI/ubuntu/BOOTAA64.CSV
           - source: grubaa64.efi
             target: EFI/ubuntu/grubaa64.efi
+          - source: mmaa64.efi
+            target: EFI/ubuntu/mmaa64.efi
           - source: shim.efi.signed
             target: EFI/ubuntu/shimaa64.efi
       - name: ubuntu-boot

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -51,27 +51,44 @@ parts:
       grub_target=x86_64
       grub_bin=grubx64.efi.signed
       shim_bin=shimx64.efi.dualsigned
+      fb_bin=fbx64.efi
+      mm_bin=mmx64.efi
+      boot_csv=BOOTX64.CSV
       if [ "$CRAFT_TARGET_ARCH" = arm64 ]; then
           grub_target=arm64
           grub_bin=grubaa64.efi.signed
           shim_bin=shimaa64.efi.dualsigned
+          fb_bin=fbaa64.efi
+          mm_bin=mmaa64.efi
+          boot_csv=BOOTAA64.CSV
       fi
 
       # Make sure we have signatures from the UC certificates
       shim_path="$CRAFT_PART_INSTALL"/usr/lib/shim/$shim_bin
       grub_path="$CRAFT_PART_INSTALL"/usr/lib/grub/"$grub_target"-efi-signed/$grub_bin
+      fb_path="$CRAFT_PART_INSTALL"/usr/lib/shim/$fb_bin
+      mm_path="$CRAFT_PART_INSTALL"/usr/lib/shim/$mm_bin
+      csv_path="$CRAFT_PART_INSTALL"/usr/lib/shim/$boot_csv
       sbverify --list "$shim_path" | grep -E 'Canonical Ltd. Secure Boot Signing \(Ubuntu Core'
       sbverify --list "$grub_path" | grep -E 'Canonical Ltd. Secure Boot Signing \(Ubuntu Core'
+      sbverify --list "$fb_path"   | grep -E 'Canonical Ltd. Secure Boot Signing \(Ubuntu Core'
+      sbverify --list "$mm_path"   | grep -E 'Canonical Ltd. Secure Boot Signing \(Ubuntu Core'
 
-      # Move shim/grub to the expected path
+      # Move assets to the expected paths
       install -m 644 "$shim_path" "$CRAFT_PART_INSTALL"/shim.efi.signed
       install -m 644 "$grub_path" "$CRAFT_PART_INSTALL"/${grub_bin%.signed}
+      install -m 644 "$fb_path"   "$CRAFT_PART_INSTALL"/$fb_bin
+      install -m 644 "$mm_path"   "$CRAFT_PART_INSTALL"/$mm_bin
+      install -m 644 "$csv_path"  "$CRAFT_PART_INSTALL"/$boot_csv
 
       # Remove all the bits we do not need, keeping changelogs and copyrights
       # (using organize/prime is not possible due to different names per arch - x64/aa64)
       find "$CRAFT_PART_INSTALL"/ -type f,l \
                 -not -path "$SNAPCRAFT_PART_INSTALL"/shim.efi.signed \
                 -not -path "$SNAPCRAFT_PART_INSTALL"/${grub_bin%.signed} \
+                -not -path "$SNAPCRAFT_PART_INSTALL"/$fb_bin \
+                -not -path "$SNAPCRAFT_PART_INSTALL"/$mm_bin \
+                -not -path "$SNAPCRAFT_PART_INSTALL"/$boot_csv \
                 -not -path "$SNAPCRAFT_PART_INSTALL"/usr/share/doc/grub-efi-$CRAFT_TARGET_ARCH-signed/'*' \
            -and -not -path "$SNAPCRAFT_PART_INSTALL"/'usr/share/doc/shim-signed/*' \
            -delete

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -24,9 +24,9 @@ hooks:
       # DO NOT check this API key into a publicly accessible VCS
       MODEL_APIKEY: ""
 
-# Min version to support shim 15.7 and min-size
+# Min version to support shim 15.7 and min-size and assets in /EFI/ubuntu
 assumes:
-  - snapd2.60.1
+  - snapd2.61
 
 parts:
   mbr:


### PR DESCRIPTION
This PR adds fallback shim and grub EFI assets to `EFI/ubuntu/`, while leaving non-fallback assets in `EFI/BOOT/`.

This is part of larger work on the snapd side to explicitly set EFI boot variables on install, thus no longer relying on default EFI boot behavior, which can be affected by such things as attaching external media.

The corresponding snapd PR is:
- https://github.com/snapcore/snapd/pull/13205

For those internal to Canonical, the spec related to this work can be found at:
- https://docs.google.com/document/d/1s-XJ56Ur6mQdJ3gVtWdJs12odgknM_2nqQ72RzWUDho

This is a revival of previous PRs which sought to add shim fallback support:
- https://github.com/snapcore/pc-gadget/pull/55
- https://github.com/snapcore/pc-gadget/pull/56

Similar changes should be ported to core24, and perhaps backported to core20 as well (likely not core18 or core16, though).