### PR TITLE
24 Support shim fallback bootchain

### DIFF
--- a/gadget/gadget-amd64.yaml
+++ b/gadget/gadget-amd64.yaml
@@ -29,10 +29,18 @@ volumes:
         update:
           edition: 2
         content:
-          - source: grubx64.efi
-            target: EFI/boot/grubx64.efi
           - source: shim.efi.signed
-            target: EFI/boot/bootx64.efi
+            target: EFI/BOOT/BOOTX64.efi
+          - source: fbx64.efi
+            target: EFI/BOOT/fbx64.efi
+          - source: BOOTX64.CSV
+            target: EFI/ubuntu/BOOTX64.CSV
+          - source: grubx64.efi
+            target: EFI/ubuntu/grubx64.efi
+          - source: mmx64.efi
+            target: EFI/ubuntu/mmx64.efi
+          - source: shim.efi.signed
+            target: EFI/ubuntu/shimx64.efi
       - name: ubuntu-boot
         role: system-boot
         filesystem: ext4

--- a/gadget/gadget-amd64.yaml
+++ b/gadget/gadget-amd64.yaml
@@ -52,8 +52,6 @@ volumes:
         content:
           - source: grubx64.efi
             target: EFI/boot/grubx64.efi
-          - source: shim.efi.signed
-            target: EFI/boot/bootx64.efi
       - name: ubuntu-save
         role: system-save
         filesystem: ext4

--- a/gadget/gadget-arm64.yaml
+++ b/gadget/gadget-arm64.yaml
@@ -13,10 +13,18 @@ volumes:
         update:
           edition: 2
         content:
-          - source: grubaa64.efi
-            target: EFI/boot/grubaa64.efi
           - source: shim.efi.signed
-            target: EFI/boot/bootaa64.efi
+            target: EFI/BOOT/BOOTAA64.efi
+          - source: fbaa64.efi
+            target: EFI/BOOT/fbaa64.efi
+          - source: BOOTAA64.CSV
+            target: EFI/ubuntu/BOOTAA64.CSV
+          - source: grubaa64.efi
+            target: EFI/ubuntu/grubaa64.efi
+          - source: mmaa64.efi
+            target: EFI/ubuntu/mmaa64.efi
+          - source: shim.efi.signed
+            target: EFI/ubuntu/shimaa64.efi
       - name: ubuntu-boot
         role: system-boot
         filesystem: ext4

--- a/gadget/gadget-arm64.yaml
+++ b/gadget/gadget-arm64.yaml
@@ -36,8 +36,6 @@ volumes:
         content:
           - source: grubaa64.efi
             target: EFI/boot/grubaa64.efi
-          - source: shim.efi.signed
-            target: EFI/boot/bootaa64.efi
       - name: ubuntu-save
         role: system-save
         filesystem: ext4

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -25,9 +25,9 @@ hooks:
       # DO NOT check this API key into a publicly accessible VCS
       MODEL_APIKEY: ""
 
-# Min version to support shim 15.7
+# Min version to support shim 15.7 and assets in /EFI/ubuntu
 assumes:
-  - snapd2.59.3
+  - snapd2.61
 
 parts:
   mbr:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -52,27 +52,44 @@ parts:
       grub_target=x86_64
       grub_bin=grubx64.efi.signed
       shim_bin=shimx64.efi.dualsigned
+      fb_bin=fbx64.efi
+      mm_bin=mmx64.efi
+      boot_csv=BOOTX64.CSV
       if [ "$CRAFT_TARGET_ARCH" = arm64 ]; then
           grub_target=arm64
           grub_bin=grubaa64.efi.signed
           shim_bin=shimaa64.efi.dualsigned
+          fb_bin=fbaa64.efi
+          mm_bin=mmaa64.efi
+          boot_csv=BOOTAA64.CSV
       fi
 
       # Make sure we have signatures from the UC certificates
       shim_path="$CRAFT_PART_INSTALL"/usr/lib/shim/$shim_bin
       grub_path="$CRAFT_PART_INSTALL"/usr/lib/grub/"$grub_target"-efi-signed/$grub_bin
+      fb_path="$CRAFT_PART_INSTALL"/usr/lib/shim/$fb_bin
+      mm_path="$CRAFT_PART_INSTALL"/usr/lib/shim/$mm_bin
+      csv_path="$CRAFT_PART_INSTALL"/usr/lib/shim/$boot_csv
       #sbverify --list "$shim_path" | grep -E 'Canonical Ltd. Secure Boot Signing \(Ubuntu Core'
       #sbverify --list "$grub_path" | grep -E 'Canonical Ltd. Secure Boot Signing \(Ubuntu Core'
+      #sbverify --list "$fb_path"   | grep -E 'Canonical Ltd. Secure Boot Signing \(Ubuntu Core'
+      #sbverify --list "$mm_path"   | grep -E 'Canonical Ltd. Secure Boot Signing \(Ubuntu Core'
 
-      # Move shim/grub to the expected path
+      # Move assets to the expected paths
       install -m 644 "$shim_path" "$CRAFT_PART_INSTALL"/shim.efi.signed
       install -m 644 "$grub_path" "$CRAFT_PART_INSTALL"/${grub_bin%.signed}
+      install -m 644 "$fb_path"   "$CRAFT_PART_INSTALL"/$fb_bin
+      install -m 644 "$mm_path"   "$CRAFT_PART_INSTALL"/$mm_bin
+      install -m 644 "$csv_path"  "$CRAFT_PART_INSTALL"/$boot_csv
 
       # Remove all the bits we do not need, keeping changelogs and copyrights
       # (using organize/prime is not possible due to different names per arch - x64/aa64)
       find "$CRAFT_PART_INSTALL"/ -type f,l \
                 -not -path "$SNAPCRAFT_PART_INSTALL"/shim.efi.signed \
                 -not -path "$SNAPCRAFT_PART_INSTALL"/${grub_bin%.signed} \
+                -not -path "$SNAPCRAFT_PART_INSTALL"/$fb_bin \
+                -not -path "$SNAPCRAFT_PART_INSTALL"/$mm_bin \
+                -not -path "$SNAPCRAFT_PART_INSTALL"/$boot_csv \
                 -not -path "$SNAPCRAFT_PART_INSTALL"/usr/share/doc/grub-efi-$CRAFT_TARGET_ARCH-signed/'*' \
            -and -not -path "$SNAPCRAFT_PART_INSTALL"/'usr/share/doc/shim-signed/*' \
            -delete


### PR DESCRIPTION
Adjust the EFI boot assets to place shim and grub binaries in `EFI/ubuntu/`, with boot and fallback binaries in `EFI/BOOT/`. Additionally, `BOOT${arch}.CSV` and `mm${arch}.efi` are placed in `EFI/ubuntu/`.

This corresponds to work being done in snapd to support shim fallback: https://github.com/snapcore/snapd/pull/13205

This corresponds to PR #106 , and is designed to be eventually backported to branches 22 and 20.

The possible boot patterns are:
1. If EFI boot variables are set correctly, boot the desired asset correctly (namely, `EFI/ubuntu/shim${arch}.efi`).
2. If the system supports fallback, then `EFI/BOOT/fb${arch}.efi` is run, which searches for `BOOT${arch}.CSV`, finds it in `EFI/ubuntu/`, and thus boots the corresponding assets in `EFI/ubuntu/`.
3. If fallback is not supported, the system directly boots `EFI/BOOT/BOOT${arch}.efi`.
