### PR TITLE
Algin with stock Ubuntu desktop boot assets layout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ ARCHIVE := $(if $(findstring $(ARCH),amd64 i386),http://archive.ubuntu.com/ubunt
 EFI_ARCH_amd64 := x64
 EFI_ARCH_arm64 := aa64
 EFI_ARCH = $(EFI_ARCH_$(ARCH))
+EFI_ARCH_UPPER = $(shell echo $(EFI_ARCH) | tr '[:lower:]' '[:upper:]')
 GRUB_TARGET_amd64 := x86_64-efi-signed
 GRUB_TARGET_arm64 := arm64-efi-signed
 GRUB_TARGET = $(GRUB_TARGET_$(ARCH))
@@ -155,16 +156,20 @@ boot: $(LEGACY_BOOT)
 	$(MAKE) stage-package package=shim-signed
 
 	if [ -f "$(SHIM_LATEST)" ]; then \
-		cp $(SHIM_LATEST) shim.efi.signed; \
+		cp $(SHIM_LATEST) shim$(EFI_ARCH).efi; \
 	else \
-		cp $(SHIM_SIGNED) shim.efi.signed; \
+		cp $(SHIM_SIGNED) shim$(EFI_ARCH).efi; \
 	fi
 	cp $(STAGEDIR)/usr/lib/grub/$(GRUB_TARGET)/grub$(EFI_ARCH).efi.signed grub$(EFI_ARCH).efi
+	cp $(STAGEDIR)/usr/lib/shim/BOOT$(EFI_ARCH_UPPER).CSV BOOT$(EFI_ARCH_UPPER).CSV
+	cp $(STAGEDIR)/usr/lib/shim/fb$(EFI_ARCH).efi fb$(EFI_ARCH).efi
+	cp $(STAGEDIR)/usr/lib/shim/mm$(EFI_ARCH).efi mm$(EFI_ARCH).efi
 
 install: boot
 	mkdir -p $(DESTDIR)
 	install -m 644 \
-	    $(if $(LEGACY_BOOT),pc-boot.img pc-core.img) shim.efi.signed grub$(EFI_ARCH).efi \
+	    $(if $(LEGACY_BOOT),pc-boot.img pc-core.img) shim$(EFI_ARCH).efi grub$(EFI_ARCH).efi \
+	    BOOT$(EFI_ARCH_UPPER).CSV fb$(EFI_ARCH).efi mm$(EFI_ARCH).efi \
 	    $(DESTDIR)/
 	install -m 644 grub.conf grub.cfg $(DESTDIR)/
 	# For classic builds we also need to prime the gadget.yaml
@@ -175,7 +180,8 @@ install: boot
 # only used locally, not relevant for snapcraft, livecd-rootfs or ubuntu-image
 clean:
 	rm -rf $(STAGEDIR)
-	rm -f pc-boot.img pc-core.img shim.efi.signed grub$(EFI_ARCH).efi
+	rm -f pc-boot.img pc-core.img shim$(EFI_ARCH).efi grub$(EFI_ARCH).efi \
+	    BOOT$(EFI_ARCH_UPPER).CSV fb$(EFI_ARCH).efi mm$(EFI_ARCH).efi
 	rm -f gadget.yaml
 	rm -rf $(DESTDIR)
 

--- a/gadget-amd64.yaml
+++ b/gadget-amd64.yaml
@@ -18,11 +18,21 @@ volumes:
         type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         filesystem: vfat
         filesystem-label: system-boot
-        size: 50M
+        size: 1G
         content:
-          - source: grubx64.efi
-            target: EFI/boot/grubx64.efi
-          - source: shim.efi.signed
-            target: EFI/boot/bootx64.efi
+          - source: shimx64.efi
+            target: EFI/BOOT/BOOTX64.EFI
+          - source: fbx64.efi
+            target: EFI/BOOT/fbx64.efi
+          - source: mmx64.efi
+            target: EFI/BOOT/mmx64.efi
+          - source: BOOTX64.CSV
+            target: EFI/ubuntu/BOOTX64.CSV
           - source: grub.cfg
             target: EFI/ubuntu/grub.cfg
+          - source: grubx64.efi
+            target: EFI/ubuntu/grubx64.efi
+          - source: mmx64.efi
+            target: EFI/ubuntu/mmx64.efi
+          - source: shimx64.efi
+            target: EFI/ubuntu/shimx64.efi

--- a/gadget-arm64.yaml
+++ b/gadget-arm64.yaml
@@ -6,11 +6,21 @@ volumes:
         type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         filesystem: vfat
         filesystem-label: system-boot
-        size: 50M
+        size: 1G
         content:
+          - source: shimaa64.efi
+            target: EFI/BOOT/BOOTAA64.efi
+          - source: fbaa64.efi
+            target: EFI/BOOT/fbaa64.efi
+          - source: mmaa64.efi
+            target: EFI/BOOT/mmaa64.efi
+          - source: BOOTAA64.CSV
+            target: EFI/ubuntu/BOOTAA64.CSV
           - source: grubaa64.efi
-            target: EFI/boot/grubaa64.efi
-          - source: shim.efi.signed
-            target: EFI/boot/bootaa64.efi
+            target: EFI/ubuntu/grubaa64.efi
           - source: grub.cfg
             target: EFI/ubuntu/grub.cfg
+          - source: mmaa64.efi
+            target: EFI/ubuntu/mmaa64.efi
+          - source: shimaa64.efi
+            target: EFI/ubuntu/shimaa64.efi

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -10,17 +10,13 @@ confinement: strict
 icon: icon.png
 
 parts:
-  gadget-yaml:
-    plugin: nil
-    override-build: |
-      # snapcraft reads gadget.yaml from project dir
-      install -m 644 gadget-$SNAPCRAFT_TARGET_ARCH.yaml $SNAPCRAFT_PROJECT_DIR/gadget.yaml
   grub-prepare:
     plugin: nil
     stage-packages:
-      - grub-efi-amd64-signed
-      - grub-pc-bin
       - shim-signed
+      - grub-efi-${SNAPCRAFT_TARGET_ARCH}-signed
+      - to amd64:
+        - grub-pc-bin
     prime: [ -* ]
   grub:
     source: .
@@ -28,4 +24,8 @@ parts:
       - grub-common
     plugin: make
     after: [grub-prepare]
-
+    override-build: |
+      make install
+      cp -r install/* ${SNAPCRAFT_PART_INSTALL}
+      # snapcraft reads gadget.yaml from project dir
+      install -m 644 gadget-${SNAPCRAFT_TARGET_ARCH}.yaml ${SNAPCRAFT_PROJECT_DIR}/gadget.yaml


### PR DESCRIPTION
The EFI boot assets layout of the classic gadget is different from the stock Ubuntu desktop version.
It's better to align them to ensure the same user experience.

And refine Makefile and snapcraft.yaml to support the snap package building correctly with amd64 and arm64 architecture.
Confirmed the default make build still working well after the refinement.