### PR TITLE
Clean-up gadget*.yaml files and verify signatures of shim/grub

### DIFF
--- a/gadget/gadget-amd64.yaml
+++ b/gadget/gadget-amd64.yaml
@@ -9,11 +9,12 @@ volumes:
         size: 440
         update:
           edition: 1
+        # This mbr simply writes an error to the console, as this
+        # gadget supports gpt only
         content:
           - image: mbr.img
-        # This one should be removed in core24
-        # or if we find a way to allow updates without keeping
-        # all partitions
+        # This one should be removed if we find a way to allow updates
+        # without keeping all partitions.
       - name: BIOS Boot
         type: 21686148-6449-6E6F-744E-656564454649
         size: 1M
@@ -25,6 +26,7 @@ volumes:
         filesystem: vfat
         # UEFI will boot the ESP partition by default first
         type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+        # Size of around two seeds to allow for remodeling
         size: 1200M
         update:
           edition: 2
@@ -37,19 +39,20 @@ volumes:
         role: system-boot
         filesystem: ext4
         type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
-        # whats the appropriate size?
+        # Around 300M would be enough, but keeping as is to allow
+        # remodeling from previous releases
         size: 750M
         update:
           edition: 1
         content:
           - source: grubx64.efi
             target: EFI/boot/grubx64.efi
-          - source: shim.efi.signed
-            target: EFI/boot/bootx64.efi
       - name: ubuntu-save
         role: system-save
         filesystem: ext4
         type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+        # min-size to allow remodeling from previous releases
+        min-size: 16M
         size: 32M
       - name: ubuntu-data
         role: system-data

--- a/gadget/gadget-arm64.yaml
+++ b/gadget/gadget-arm64.yaml
@@ -9,6 +9,7 @@ volumes:
         filesystem: vfat
         # UEFI will boot the ESP partition by default first
         type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+        # Size of around two seeds to allow for remodeling
         size: 1200M
         update:
           edition: 2
@@ -21,15 +22,14 @@ volumes:
         role: system-boot
         filesystem: ext4
         type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
-        # whats the appropriate size?
+        # Around 300M would be enough, but keeping as is to allow
+        # remodeling from previous releases
         size: 750M
         update:
           edition: 1
         content:
           - source: grubaa64.efi
             target: EFI/boot/grubaa64.efi
-          - source: shim.efi.signed
-            target: EFI/boot/bootaa64.efi
       - name: ubuntu-save
         role: system-save
         filesystem: ext4

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -58,11 +58,11 @@ parts:
           shim_bin=shimaa64.efi.dualsigned
       fi
 
-      # Make sure we have signatures from the UC certificates
+      # Make sure we have have the right signatures
       shim_path="$CRAFT_PART_INSTALL"/usr/lib/shim/$shim_bin
       grub_path="$CRAFT_PART_INSTALL"/usr/lib/grub/"$grub_target"-efi-signed/$grub_bin
-      #sbverify --list "$shim_path" | grep -E 'Canonical Ltd. Secure Boot Signing \(Ubuntu Core'
-      #sbverify --list "$grub_path" | grep -E 'Canonical Ltd. Secure Boot Signing \(Ubuntu Core'
+      sbverify --list "$shim_path" | grep -E 'Canonical Ltd. Secure Boot Signing \(2022 v1\)'
+      sbverify --list "$grub_path" | grep -E 'Canonical Ltd. Secure Boot Signing \(2022 v1\)'
 
       # Move shim/grub to the expected path
       install -m 644 "$shim_path" "$CRAFT_PART_INSTALL"/shim.efi.signed


### PR DESCRIPTION
snapcraft.yaml: verify shim/grub are signed with a Canonical key

This key is not Ubuntu Core only anymore (see spec KE009 for the
reasons to drop this key).