### PR TITLE
gadget: use new boot chain

### DIFF
--- a/gadget/gadget-amd64.yaml
+++ b/gadget/gadget-amd64.yaml
@@ -32,7 +32,13 @@ volumes:
           edition: 2
         content:
           - source: grubx64.efi
-            target: EFI/boot/grubx64.efi
+            target: EFI/ubuntu/grubx64.efi
+          - source: shim.efi.signed
+            target: EFI/ubuntu/shimx64.efi
+          - source: boot.csv
+            target: EFI/ubuntu/bootx64.csv
+          - source: fb.efi
+            target: EFI/boot/fbx64.efi
           - source: shim.efi.signed
             target: EFI/boot/bootx64.efi
       - name: ubuntu-boot

--- a/gadget/gadget-arm64.yaml
+++ b/gadget/gadget-arm64.yaml
@@ -15,7 +15,13 @@ volumes:
           edition: 2
         content:
           - source: grubaa64.efi
-            target: EFI/boot/grubaa64.efi
+            target: EFI/ubuntu/grubaa64.efi
+          - source: shim.efi.signed
+            target: EFI/ubuntu/shimaa64.efi
+          - source: boot.csv
+            target: EFI/ubuntu/bootaa64.csv
+          - source: fb.efi
+            target: EFI/boot/fbaa64.efi
           - source: shim.efi.signed
             target: EFI/boot/bootaa64.efi
       - name: ubuntu-boot

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -51,14 +51,20 @@ parts:
       grub_target=x86_64
       grub_bin=grubx64.efi.signed
       shim_bin=shimx64.efi.dualsigned
+      fb_bin=fbx64.efi
+      boot_csv=BOOTX64.CSV
       if [ "${CRAFT_ARCH_BUILD_FOR}" = arm64 ]; then
           grub_target=arm64
           grub_bin=grubaa64.efi.signed
           shim_bin=shimaa64.efi.dualsigned
+          fb_bin=fbaa64.efi
+          boot_csv=bootaa64.csv
       fi
 
       # Make sure we have have the right signatures
       shim_path="${CRAFT_PART_INSTALL}"/usr/lib/shim/$shim_bin
+      fb_path="${CRAFT_PART_INSTALL}/usr/lib/shim/${fb_bin}"
+      bootcsv_path="${CRAFT_PART_INSTALL}/usr/lib/shim/${boot_csv}"
       grub_path="${CRAFT_PART_INSTALL}"/usr/lib/grub/"$grub_target"-efi-signed/$grub_bin
       sbverify --list "$shim_path" | grep -E 'Canonical Ltd. Secure Boot Signing \(2022 v1\)'
       sbverify --list "$grub_path" | grep -E 'Canonical Ltd. Secure Boot Signing \(2022 v1\)'
@@ -66,12 +72,16 @@ parts:
       # Move shim/grub to the expected path
       install -m 644 "$shim_path" "${CRAFT_PART_INSTALL}"/shim.efi.signed
       install -m 644 "$grub_path" "${CRAFT_PART_INSTALL}"/${grub_bin%.signed}
+      install -m 644 "${fb_path}" "${CRAFT_PART_INSTALL}/fb.efi"
+      install -m 644 "${bootcsv_path}" "${CRAFT_PART_INSTALL}/boot.csv"
 
       # Remove all the bits we do not need, keeping changelogs and copyrights
       # (using organize/prime is not possible due to different names per arch - x64/aa64)
       find "${CRAFT_PART_INSTALL}"/ -type f,l \
                 -not -path "${CRAFT_PART_INSTALL}"/shim.efi.signed \
                 -not -path "${CRAFT_PART_INSTALL}"/${grub_bin%.signed} \
+                -not -path "${CRAFT_PART_INSTALL}"/fb.efi \
+                -not -path "${CRAFT_PART_INSTALL}"/boot.csv \
                 -not -path "${CRAFT_PART_INSTALL}"/usr/share/doc/grub-efi-${CRAFT_ARCH_BUILD_FOR}-signed/'*' \
            -and -not -path "${CRAFT_PART_INSTALL}"/'usr/share/doc/shim-signed/*' \
            -delete


### PR DESCRIPTION
pc-gadget provides the shim boot chain for removable media. This is not the proper boot chain for an installed system.
    
The difference between boot chains is explained upstream: https://github.com/rhboot/shim/blob/main/README.fallback
    
This does not introduce the MOK manager yet.
    
This depends on snapd 2.63 because downgrade would require removing `EFI/boot/fbx64.efi`.

Depends on:
* https://github.com/snapcore/snapd/pull/13412
* https://github.com/snapcore/snapd/pull/13734