### PR TITLE
Define a system-data volume with 5GB size (LP#2064322)

### DIFF
--- a/gadget-arm64.yaml
+++ b/gadget-arm64.yaml
@@ -14,3 +14,9 @@ volumes:
             target: EFI/boot/bootaa64.efi
           - source: grub.cfg
             target: EFI/ubuntu/grub.cfg
+      - name: writable
+        role: system-data
+        filesystem: ext4
+        filesystem-label: writable
+        type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+        size: 5G


### PR DESCRIPTION
ubuntu-images fails to create valid GPT partition table (the backup GPT header isn't located at the right position and also invalid) when the gadget snap doesn't include an explicit system-data structure.
Defining one here with 5G size (that suits the 4,8GB of rootfs partition for ubuntu-tegra classic server images), and using the "writable" name/label to keep the same image attribute.