### PR TITLE
increase ESP partition for compatibility

### DIFF
--- a/gadget-amd64.yaml
+++ b/gadget-amd64.yaml
@@ -18,7 +18,8 @@ volumes:
         type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         filesystem: vfat
         filesystem-label: system-boot
-        size: 256M
+        min-size: 256M
+        size: 260M
         content:
           - source: shimx64.efi
             target: EFI/BOOT/BOOTX64.EFI

--- a/gadget-arm64.yaml
+++ b/gadget-arm64.yaml
@@ -6,7 +6,8 @@ volumes:
         type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         filesystem: vfat
         filesystem-label: system-boot
-        size: 256M
+        min-size: 256M
+        size: 260M
         content:
           - source: shimaa64.efi
             target: EFI/BOOT/BOOTAA64.efi


### PR DESCRIPTION
When the ESP partition is 256MB and the disk is using 4K sector size, mkfs.fat will prompt:
> WARNING: Number of clusters for 32 bit FAT is less than suggested minimum.

Based on the implementation, the data area (i.e., **without** FAT32 header, reserved sectors and alignments/offset) should be larger than 65525 sectors. Therefore, 256MB is not enough for disks using 4K sector size.

Use `truncate -s $((65696*4096)) part.bin; mkfs.fat -F 32 -S 4096 -v part.bin` to verify if the sector number is enough. By giving different FAT settings, the necessary size might by changed.

For better compatibility and increasing 4MB doesn't consume a lot of disk space, it'd be good to have a bigger ESP partition.

Reference:
[1] mkfs.fat - https://github.com/dosfstools/dosfstools/blob/master/src/mkfs.fat.c
[2] https://superuser.com/questions/1702331/what-is-the-minimum-size-of-a-4k-native-partition-when-formatted-with-fat32