### PR TITLE
Enable plymouth in classic 26.04

### DIFF
--- a/gadget/gadget-amd64.yaml
+++ b/gadget/gadget-amd64.yaml
@@ -1,3 +1,7 @@
+kernel-cmdline:
+  append:
+    - quiet
+    - splash
 volumes:
   pc:
     schema: gpt

--- a/gadget/gadget-arm64.yaml
+++ b/gadget/gadget-arm64.yaml
@@ -1,3 +1,7 @@
+kernel-cmdline:
+  append:
+    - quiet
+    - splash
 volumes:
   pc:
     # bootloader configuration is shipped and managed by snapd


### PR DESCRIPTION
We need plymouth only on classic, not on Ubuntu core. Ensure the right kernel parameters are there.