### PR TITLE
prepare-device: add Model Service reference URL

### DIFF
--- a/snap/hooks/prepare-device
+++ b/snap/hooks/prepare-device
@@ -19,5 +19,10 @@ exec >> $SNAP_COMMON/prepare-device-hook.log 2>&1
 # implement your preferred way of generating a serial number for this device here
 snapctl set registration.proposed-serial="\"$(date -u)\""
 
+# If you are using the Model Service, use the below:
+snapctl set device-service.url="https://api.snapcraft.io/v1/"
+
+# If you are using the legacy Serial Vault, use the below:
 snapctl set device-service.url="https://serial-vault-partners.canonical.com/v1/"
+
 snapctl set device-service.headers="{\"api-key\": \"$MODEL_APIKEY\"}"

--- a/snap/hooks/prepare-device
+++ b/snap/hooks/prepare-device
@@ -19,10 +19,10 @@ exec >> $SNAP_COMMON/prepare-device-hook.log 2>&1
 # implement your preferred way of generating a serial number for this device here
 snapctl set registration.proposed-serial="\"$(date -u)\""
 
-# If you are using the Model Service, use the below:
-snapctl set device-service.url="https://api.snapcraft.io/v1/"
+# If you are using the Model Service, uncomment the below:
+# snapctl set device-service.url="https://api.snapcraft.io/v1/"
 
-# If you are using the legacy Serial Vault, use the below:
-snapctl set device-service.url="https://serial-vault-partners.canonical.com/v1/"
+# If you are using the legacy Serial Vault, uncomment the below:
+# snapctl set device-service.url="https://serial-vault-partners.canonical.com/v1/"
 
 snapctl set device-service.headers="{\"api-key\": \"$MODEL_APIKEY\"}"


### PR DESCRIPTION
The Model Service should be accessed using its proper URL. A forward will generally be setup from the legacy Serial Vault URL to the new Model Service as part of the Model Service provisioning process, but you should aim to use the proper URL whenever possible. New customers being onboarded shouldn't have a Serial Vault at all, so the serial-vault-partners URL won't be helpful to them.

There are a few other changes currently in-flight which should coincide with this one happening, though I'd argue this takes precedent.

https://github.com/canonical/brand-store-documentation/pull/111
https://github.com/canonical/ubuntu-core-docs/pull/337
https://github.com/canonical/snap-docs/pull/259